### PR TITLE
FindNodeByInterface()を共通関数化

### DIFF
--- a/Scripts/ARBridge/ShareSim/Baggage/BaggageGrabber.cs
+++ b/Scripts/ARBridge/ShareSim/Baggage/BaggageGrabber.cs
@@ -34,36 +34,12 @@ namespace hakoniwa.ar.bridge.sharesim
 
         private void Start()
         {
-//            magnet = FindComponent<Magnet>(this);
-            magnet = FindNodeByInterface<Magnet>(this);
+            magnet = NodeUtil.FindNodeByInterface<Magnet>(this);
             if (magnet == null)
             {
                 throw new System.Exception("Can not find magnet on " + this.Name);
             }
             currentBaggage = null;
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         private async Task<Baggage> RequestGrabAsync(uint owner_id, IPduManager pduManager)

--- a/Scripts/ARBridge/ShareSim/Baggage/BaggagePhysics.cs
+++ b/Scripts/ARBridge/ShareSim/Baggage/BaggagePhysics.cs
@@ -11,35 +11,11 @@ namespace hakoniwa.ar.bridge.sharesim
 
         public void Initialize(Node target)
         {
-//            baggage = FindComponent<Baggage>(target);
-            baggage = FindNodeByInterface<Baggage>(target);
+            baggage = NodeUtil.FindNodeByInterface<Baggage>(target);
             if (baggage == null)
             {
                 throw new System.Exception("Can not find baggage on " + target.Name);
             }
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void StartPhysics()

--- a/Scripts/ARBridge/ShareSim/ShareSimObject.cs
+++ b/Scripts/ARBridge/ShareSim/ShareSimObject.cs
@@ -55,43 +55,18 @@ namespace hakoniwa.ar.bridge.sharesim
                 throw new System.Exception("Can not find target_object");
             }
 
-//            physics = FindComponent<IShareSimPhysics>(target_object);
-            physics = FindNodeByInterface<IShareSimPhysics>(target_object);
+            physics = NodeUtil.FindNodeByInterface<IShareSimPhysics>(target_object);
             if (physics == null)
             {
                 throw new System.Exception("Can not find IShareSimPhysics on " + target_object.Name);
             }
-//            avatar = FindComponent<IShareSimAvatar>(target_object);
-            avatar = FindNodeByInterface<IShareSimAvatar>(target_object);
+            avatar = NodeUtil.FindNodeByInterface<IShareSimAvatar>(target_object);
             if (avatar == null)
             {
                 throw new System.Exception("Can not find IShareSimAvatar on " + target_object.Name);
             }
             physics.Initialize(target_object);
             avatar.Initialize(target_object);
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void DoStart()

--- a/Scripts/Drone/BoundaryManager.cs
+++ b/Scripts/Drone/BoundaryManager.cs
@@ -89,8 +89,7 @@ namespace hakoniwa.drone
 
         Vector3 GetPlaneCenterWorld(Node3D plane)
         {
-//            var mi = FindComponent<MeshInstance3D>(plane);
-            var mi = FindNodeByInterface<MeshInstance3D>(plane);
+            var mi = NodeUtil.FindNodeByInterface<MeshInstance3D>(plane);
             if (mi != null && mi.Mesh != null)
             {
                 return plane.ToGlobal(mi.Mesh.GetAabb().GetCenter());
@@ -100,8 +99,7 @@ namespace hakoniwa.drone
 
         Vector2 GetPlaneSizeWorld(Node3D plane)
         {
-//            var mi = FindComponent<MeshInstance3D>(plane);
-            var mi = FindNodeByInterface<MeshInstance3D>(plane);
+            var mi = NodeUtil.FindNodeByInterface<MeshInstance3D>(plane);
             if (mi == null || mi.Mesh == null) return Vector2.Zero;
 
             Aabb aabb = mi.Mesh.GetAabb();
@@ -116,29 +114,6 @@ namespace hakoniwa.drone
         Vector3 GetPlaneNormalWorld(Node3D plane, Vector3 localNormal)
         {
             return (plane.GlobalTransform.Basis * localNormal).Normalized();
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         static Vector3 UnityToRos(Vector3 v) => new Vector3(v.Z, -v.X, v.Y);

--- a/Scripts/Drone/DisturbanceArea.cs
+++ b/Scripts/Drone/DisturbanceArea.cs
@@ -25,8 +25,7 @@ namespace hakoniwa.drone
 
         private void OnBodyEntered(Node3D body)
         {
-//            var target = FindComponentInParent<IDroneDisturbableObject>(body);
-            var target = FindNodeByInterface<IDroneDisturbableObject>(body);
+            var target = NodeUtil.FindNodeByInterface<IDroneDisturbableObject>(body);
             if (target != null)
             {
                 target.ApplyDisturbance(temperature, windVector);
@@ -35,37 +34,11 @@ namespace hakoniwa.drone
 
         private void OnBodyExited(Node3D body)
         {
-//            var target = FindComponentInParent<IDroneDisturbableObject>(body);
-            var target = FindNodeByInterface<IDroneDisturbableObject>(body);
+            var target = NodeUtil.FindNodeByInterface<IDroneDisturbableObject>(body);
             if (target != null)
             {
                 target.ResetDisturbance();
             }
         }
-
-        private T FindComponentInParent<T>(Node node) where T : class
-        {
-            Node current = node;
-            while (current != null)
-            {
-                if (current is T found) return found;
-                current = current.GetParent();
-            }
-            return null;
-        }
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-
     }
 }

--- a/Scripts/Drone/DroneCameraController.cs
+++ b/Scripts/Drone/DroneCameraController.cs
@@ -12,39 +12,13 @@ namespace hakoniwa.drone
 
         private void Awake()
         {
-//            this.controller = this.GetComponentInChildren<ICameraController>();
-//            this.controller = FindComponent<ICameraController>(this);
-            this.controller = FindNodeByInterface<ICameraController>(this);
+            this.controller = NodeUtil.FindNodeByInterface<ICameraController>(this);
             if (this.controller == null)
             {
                 throw new Exception("Can not find ICameraController");
             }
             controller.Initialize();
         }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
 
         void LateUpdate()
         {

--- a/Scripts/Drone/DroneConfig.cs
+++ b/Scripts/Drone/DroneConfig.cs
@@ -46,43 +46,14 @@ namespace hakoniwa.drone
 //        public string drone_config_path = "./drone_config.json";
         public string drone_config_path = "drone_config.json";
 
-#if false
-        private List<T> FindComponents<T>(Node node) where T : class
-        {
-            List<T> results = new List<T>();
-            if (node is T found) results.Add(found);
-            foreach (Node child in node.GetChildren())
-            {
-                results.AddRange(FindComponents<T>(child));
-            }
-            return results;
-        }
-#else
         private List<T> FindComponents<T>() where T : class
         {
             List<T> results = new List<T>();
             var root = GetTree().Root;
-            _FindComponentsRecursive(root, results);
+            NodeUtil._FindComponentsRecursive(root, results);
             return results;
         }
 
-        private void _FindComponentsRecursive<T>(Node node, List<T> results) where T : class
-        {
-            if (node == null) return;
-
-            // 1. 自分自身が型 T にキャストできるかチェック
-            if (node is T found)
-            {
-                results.Add(found);
-            }
-
-            // 2. 子ノードに対して再帰的に処理
-            foreach (Node child in node.GetChildren())
-            {
-                _FindComponentsRecursive(child, results);
-            }
-        }
-#endif
         public void LoadDroneConfig(string droneName)
         {
 //            string filePath = drone_config_path;

--- a/Scripts/Drone/DroneControl.cs
+++ b/Scripts/Drone/DroneControl.cs
@@ -66,8 +66,7 @@ namespace hakoniwa.drone
 			}
 			else
 			{
-//				droneControlOp = FindComponent<IDroneControlOp>(this);
-				droneControlOp = FindNodeByInterface<IDroneControlOp>(this);
+				droneControlOp = NodeUtil.FindNodeByInterface<IDroneControlOp>(this);
 			}
 			if (droneControlOp != null)
 			{
@@ -76,8 +75,7 @@ namespace hakoniwa.drone
 
 			if (grabberObject != null)
 			{
-//				grabber = FindComponent<IBaggageGrabber>(grabberObject);
-				grabber = FindNodeByInterface<IBaggageGrabber>(grabberObject);
+				grabber = NodeUtil.FindNodeByInterface<IBaggageGrabber>(grabberObject);
 				GD.Print("grabber: " + grabber);
 			}
 			else
@@ -98,30 +96,6 @@ namespace hakoniwa.drone
 				controller_input = HakoDroneXrInputManager.Instance;
 			}
 		}
-
-		private T FindComponent<T>(Node node) where T : class
-		{
-			if (node is T found) return found;
-			foreach (Node child in node.GetChildren())
-			{
-				var result = FindComponent<T>(child);
-				if (result != null) return result;
-			}
-			return null;
-		}
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
             
 		public float move_step = 1.0f; 
 		private float camera_move_button_time_duration = 0f;

--- a/Scripts/Drone/DronePlayer.cs
+++ b/Scripts/Drone/DronePlayer.cs
@@ -54,20 +54,17 @@ namespace hakoniwa.drone
 
         public override void _Ready()
         {
-//            my_collision = FindComponent<DroneCollision>(this);
-            my_collision = FindNodeByInterface<DroneCollision>(this);
+            my_collision = NodeUtil.FindNodeByInterface<DroneCollision>(this);
             if (my_collision != null)
             {
                 my_collision.SetIndex(0);
             }
-//            drone_control = FindComponent<DroneControl>(this);
-            drone_control = FindNodeByInterface<DroneControl>(this);
+            drone_control = NodeUtil.FindNodeByInterface<DroneControl>(this);
             if (drone_control == null)
             {
                 throw new Exception("Can not found drone control");
             }
-//            drone_propeller = FindComponent<DronePropeller>(this);
-            drone_propeller = FindNodeByInterface<DronePropeller>(this);
+            drone_propeller = NodeUtil.FindNodeByInterface<DronePropeller>(this);
             if (drone_propeller == null)
             {
                 GD.Print("Can not found drone propeller");
@@ -149,29 +146,6 @@ namespace hakoniwa.drone
             }
         }
 
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-         
         private string LoadTextFromResources(string resourcePath)
         {
             if (!FileAccess.FileExists(resourcePath)) return null;

--- a/Scripts/Drone/DronePropeller.cs
+++ b/Scripts/Drone/DronePropeller.cs
@@ -35,8 +35,7 @@ namespace hakoniwa.drone
 
 		public override void _Ready()
 		{
-//			audioSource = FindComponent<AudioStreamPlayer3D>(this);
-			audioSource = FindNodeByInterface<AudioStreamPlayer3D>(this);
+			audioSource = NodeUtil.FindNodeByInterface<AudioStreamPlayer3D>(this);
 			if (audioSource == null && enableAudio)
 			{
 				audioSource = new AudioStreamPlayer3D();
@@ -48,29 +47,6 @@ namespace hakoniwa.drone
 				LoadAudio();
 			}
 		}
-
-		private T FindComponent<T>(Node node) where T : class
-		{
-			if (node is T found) return found;
-			foreach (Node child in node.GetChildren())
-			{
-				var result = FindComponent<T>(child);
-				if (result != null) return result;
-			}
-			return null;
-		}
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
 
 		private void LoadAudio()
 		{

--- a/Scripts/Hakoniwa/Device/DroneAvatarDevice.cs
+++ b/Scripts/Hakoniwa/Device/DroneAvatarDevice.cs
@@ -23,8 +23,7 @@ public partial class DroneAvatarDevice : Node, IHakoniwaArObject
         {
             throw new Exception("Body is not assigned");
         }
-//        drone_propeller = FindComponent<DronePropeller>(body);
-        drone_propeller = FindNodeByInterface<DronePropeller>(body);
+        drone_propeller = NodeUtil.FindNodeByInterface<DronePropeller>(body);
         if (drone_propeller == null)
         {
             throw new Exception("Can not found drone propeller");
@@ -33,29 +32,6 @@ public partial class DroneAvatarDevice : Node, IHakoniwaArObject
     }
     
     private float[] prev_controls = new float[4];
-
-    private T FindComponent<T>(Node node) where T : class
-    {
-        if (node is T found) return found;
-        foreach (Node child in node.GetChildren())
-        {
-            var result = FindComponent<T>(child);
-            if (result != null) return result;
-        }
-        return null;
-    }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
 
     public override void _PhysicsProcess(double delta)
     {

--- a/Scripts/Hakoniwa/Device/DroneAvatarWeb.cs
+++ b/Scripts/Hakoniwa/Device/DroneAvatarWeb.cs
@@ -62,8 +62,7 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
             body = this;
         }
         
-//        drone_propeller = FindComponent<DronePropeller>(this);
-        drone_propeller = FindNodeByInterface<DronePropeller>(this);
+        drone_propeller = NodeUtil.FindNodeByInterface<DronePropeller>(this);
         if (drone_propeller == null)
         {
             GD.PrintErr("Can not found drone propeller");
@@ -73,15 +72,13 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
             GD.Print("max rotation : " + drone_propeller.maxRotationSpeed);
         }
 
-//        drone_control = FindComponent<DroneControl>(this);
-        drone_control = FindNodeByInterface<DroneControl>(this);
+        drone_control = NodeUtil.FindNodeByInterface<DroneControl>(this);
         if (drone_control == null)
         {
             GD.Print("not found DroneControl");
         }
         
-//        droneConfig = FindComponent<DroneConfig>(this);
-        droneConfig = FindNodeByInterface<DroneConfig>(this);
+        droneConfig = NodeUtil.FindNodeByInterface<DroneConfig>(this);
         if (droneConfig != null)
         {
             droneConfig.LoadDroneConfig(robotName);
@@ -90,8 +87,7 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
             GD.Print("not found DroneConfig");
         }
         
-//        drone_collision = FindComponent<DroneCollision>(this);
-        drone_collision = FindNodeByInterface<DroneCollision>(this);
+        drone_collision = NodeUtil.FindNodeByInterface<DroneCollision>(this);
         if (drone_collision != null)
         {
             GD.Print("collision is attached.");
@@ -99,65 +95,6 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
         {
             GD.Print("not found DroneCollision");
         }
-    }
-
-    private T FindComponent<T>(Node node) where T : class
-    {
-        if (node is T found) return found;
-        foreach (Node child in node.GetChildren())
-        {
-            var result = FindComponent<T>(child);
-            if (result != null) return result;
-        }
-        return null;
-    }
-#if false
-    private List<T> FindComponents<T>(Node node) where T : class
-    {
-        List<T> results = new List<T>();
-        if (node is T found) results.Add(found);
-        foreach (Node child in node.GetChildren())
-        {
-            results.AddRange(FindComponents<T>(child));
-        }
-        return results;
-    }
-#else
-    private List<T> FindComponents<T>() where T : class
-    {
-        List<T> results = new List<T>();
-        var root = GetTree().Root;
-        _FindComponentsRecursive(root, results);
-        return results;
-    }
-
-    private void _FindComponentsRecursive<T>(Node node, List<T> results) where T : class
-    {
-        if (node == null) return;
-
-        // 1. 自分自身が型 T にキャストできるかチェック
-        if (node is T found)
-        {
-            results.Add(found);
-        }
-
-        // 2. 子ノードに対して再帰的に処理
-        foreach (Node child in node.GetChildren())
-        {
-            _FindComponentsRecursive(child, results);
-        }
-    }
-#endif
-    public T FindNodeByInterface<T>(Node root) where T : class
-    {
-        if (root is T found) return found;
-
-        foreach (Node child in root.GetChildren())
-        {
-            var result = FindNodeByInterface<T>(child);
-            if (result != null) return result;
-        }
-        return null;
     }
 
     private float[] prev_controls = new float[4];
@@ -381,16 +318,14 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
         
         if (camera_controller != null) camera_controller.GetCameraController().DelclarePdu(robotName, p_manager);
         
-//        var local_lidars_test = FindComponent<ILiDAR3DController>(this);
-        var local_lidars_test = FindNodeByInterface<ILiDAR3DController>(this);
+        var local_lidars_test = NodeUtil.FindNodeByInterface<ILiDAR3DController>(this);
         if (local_lidars_test != null)
         {
             await p_manager.DeclarePduForWrite(robotName, "lidar_pos");
             await p_manager.DeclarePduForWrite(robotName, "lidar_point_cloud");
         }
         
-//        wind = FindComponent<Wind>(this);
-        var wind = FindNodeByInterface<Wind>(this);
+        var wind = NodeUtil.FindNodeByInterface<Wind>(this);
         if (wind != null) await p_manager.DeclarePduForRead(robotName, pdu_name_disturbance);
         
         await p_manager.DeclarePduForRead(robotName, pdu_name_status);
@@ -417,4 +352,13 @@ public partial class DroneAvatarWeb : Node3D, IHakoniwaWebObject, IDroneBatteryS
                 sea_level_atm,
                 sea_level_temperature));
     }
+
+    private List<T> FindComponents<T>() where T : class
+    {
+        List<T> results = new List<T>();
+        var root = GetTree().Root;
+        NodeUtil._FindComponentsRecursive(root, results);
+        return results;
+    }
+
 }

--- a/Scripts/Hakoniwa/Device/DronePlayerDevice.cs
+++ b/Scripts/Hakoniwa/Device/DronePlayerDevice.cs
@@ -133,26 +133,22 @@ public partial class DronePlayerDevice : Node, IHakoniwaArObject, IDroneDisturba
             sharesim_client = ShareSimClient.Instance;
             ibridge = HakoniwaArBridgeDevice.Instance;
         }
-//        my_collision = FindComponent<DroneCollision>(this);
-        my_collision = FindNodeByInterface<DroneCollision>(this);
+        my_collision = NodeUtil.FindNodeByInterface<DroneCollision>(this);
         if (my_collision == null) {
             throw new Exception("Can not found collision");
         }
-//        drone_control = FindComponent<DroneControl>(this);
-        drone_control = FindNodeByInterface<DroneControl>(this);
+        drone_control = NodeUtil.FindNodeByInterface<DroneControl>(this);
         if (drone_control == null)
         {
             throw new Exception("Can not found drone control");
         }
-//        drone_propeller = FindComponent<DronePropeller>(this);
-        drone_propeller = FindNodeByInterface<DronePropeller>(this);
+        drone_propeller = NodeUtil.FindNodeByInterface<DronePropeller>(this);
         if (drone_propeller == null)
         {
             throw new Exception("Can not found drone propeller");
         }
         my_collision.SetIndex(0);
-//        baggage_grabber = FindComponent<BaggageGrabber>(this);
-        baggage_grabber = FindNodeByInterface<BaggageGrabber>(this);
+        baggage_grabber = NodeUtil.FindNodeByInterface<BaggageGrabber>(this);
     
         if (baggage_grabber == null)
         {
@@ -189,8 +185,7 @@ public partial class DronePlayerDevice : Node, IHakoniwaArObject, IDroneDisturba
         /*
          * Camera
          */
-//        camera_controller = FindComponent<ICameraController>(this);
-        camera_controller = FindNodeByInterface<ICameraController>(this);
+        camera_controller = NodeUtil.FindNodeByInterface<ICameraController>(this);
         if (camera_controller != null)
         {
             GD.Print("Camera is enabled");
@@ -233,29 +228,6 @@ public partial class DronePlayerDevice : Node, IHakoniwaArObject, IDroneDisturba
         {
             GD.PrintErr("Can not Start DroneService RC");
         }
-    }
-
-    private T FindComponent<T>(Node node) where T : class
-    {
-        if (node is T found) return found;
-        foreach (Node child in node.GetChildren())
-        {
-            var result = FindComponent<T>(child);
-            if (result != null) return result;
-        }
-        return null;
-    }
-
-    public T FindNodeByInterface<T>(Node root) where T : class
-    {
-        if (root is T found) return found;
-
-        foreach (Node child in root.GetChildren())
-        {
-            var result = FindNodeByInterface<T>(child);
-            if (result != null) return result;
-        }
-        return null;
     }
 
     private string LoadTextFromResources(string resourcePath)

--- a/Scripts/Hakoniwa/HakoSim/Drone/BaggageGrabber.cs
+++ b/Scripts/Hakoniwa/HakoSim/Drone/BaggageGrabber.cs
@@ -28,38 +28,12 @@ namespace hakoniwa.drone.sim
             {
                 throw new ArgumentException($"Can not declare pdu for read: {robotName} {pdu_name_status_magnet}");
             }
-//            magnet = FindComponent<Magnet>(this);
-            magnet = FindNodeByInterface<Magnet>(this);
+            magnet = NodeUtil.FindNodeByInterface<Magnet>(this);
             if(magnet == null)
             {
                 throw new ArgumentException($"Can not find Magnet on: {robotName}");
             }
         }
-
-        
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
 
         public void DoControl(IPduManager pduManager)
         {

--- a/Scripts/Hakoniwa/HakoSim/Drone/CameraController.cs
+++ b/Scripts/Hakoniwa/HakoSim/Drone/CameraController.cs
@@ -30,24 +30,12 @@ namespace hakoniwa.drone.sim
 
         public override void _Ready()
         {
-//            this.controller = FindComponent<ICameraController>(GetParent());
             this.controller = controllerNode as ICameraController;
             if (this.controller == null)
             {
                 throw new Exception("Can not find ICameraController");
             }
             controller.Initialize();
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void DoInitialize(string robot_name, IHakoPdu hakoPdu)
@@ -90,7 +78,7 @@ namespace hakoniwa.drone.sim
                     this.controller = controllerNode as ICameraController;
                 
                 if (this.controller == null)
-                    this.controller = FindComponent<ICameraController>(GetParent());
+                    this.controller = NodeUtil.FindNodeByInterface<ICameraController>(GetParent());
             }
 
             if (this.controller == null)

--- a/Scripts/Hakoniwa/HakoSim/Drone/DroneAvatar.cs
+++ b/Scripts/Hakoniwa/HakoSim/Drone/DroneAvatar.cs
@@ -98,8 +98,7 @@ namespace hakoniwa.drone.sim
              }
 
             // Recursive searches
-//            drone_propeller = FindComponent<DronePropeller>(this);
-            drone_propeller = FindNodeByInterface<DronePropeller>(this);
+            drone_propeller = NodeUtil.FindNodeByInterface<DronePropeller>(this);
              if (drone_propeller != null)
              {
                  GD.Print("DroneAvatar: DronePropeller found.");
@@ -116,29 +115,21 @@ namespace hakoniwa.drone.sim
             {
                 GD.PrintErr("DroneAvatar Error: DronePropeller component not found! LED state will not change.");
             }
-//            drone_collision = FindComponent<DroneCollision>(this);
-//            drone_collision = FindNodeByInterface<DroneCollision>(this);
             drone_collision = droneCollisionNode as DroneCollision;
 
-//            touchSensor = FindComponent<TouchSensor>(this);
-            touchSensor = FindNodeByInterface<TouchSensor>(this);
+            touchSensor = NodeUtil.FindNodeByInterface<TouchSensor>(this);
 
-//            gameController = FindComponent<GameController>(this);
-            gameController = FindNodeByInterface<GameController>(this);
+            gameController = NodeUtil.FindNodeByInterface<GameController>(this);
 
-//            cameraController = FindComponent<CameraController>(this);
-            cameraController = FindNodeByInterface<CameraController>(this);
+            cameraController = NodeUtil.FindNodeByInterface<CameraController>(this);
 
-//            baggageGrabber = FindComponent<BaggageGrabber>(this);
-            baggageGrabber = FindNodeByInterface<BaggageGrabber>(this);
+            baggageGrabber = NodeUtil.FindNodeByInterface<BaggageGrabber>(this);
 
-//            droneConfig = FindComponent<DroneConfig>(this);
-            droneConfig = FindNodeByInterface<DroneConfig>(this);
+            droneConfig = NodeUtil.FindNodeByInterface<DroneConfig>(this);
 
             lidars = FindComponents<ILiDAR3DController>();
 
-//            wind = FindComponent<Wind>(this);
-            wind = FindNodeByInterface<Wind>(this);
+            wind = NodeUtil.FindNodeByInterface<Wind>(this);
 
              if (touchSensor != null)
              {
@@ -233,64 +224,12 @@ namespace hakoniwa.drone.sim
             foreach (var w in propeller_winds) w.SetWindVelocityFromRos(Godot.Vector3.Zero);
         }
 
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-#if false
-        private List<T> FindComponents<T>(Node node) where T : class
-        {
-            List<T> results = new List<T>();
-            if (node is T found) results.Add(found);
-            foreach (Node child in node.GetChildren())
-            {
-                results.AddRange(FindComponents<T>(child));
-            }
-            return results;
-        }
-#else
         private List<T> FindComponents<T>() where T : class
         {
             List<T> results = new List<T>();
             var root = GetTree().Root;
-            _FindComponentsRecursive(root, results);
+            NodeUtil._FindComponentsRecursive(root, results);
             return results;
-        }
-
-        private void _FindComponentsRecursive<T>(Node node, List<T> results) where T : class
-        {
-            if (node == null) return;
-
-            // 1. 自分自身が型 T にキャストできるかチェック
-            if (node is T found)
-            {
-                results.Add(found);
-            }
-
-            // 2. 子ノードに対して再帰的に処理
-            foreach (Node child in node.GetChildren())
-            {
-                _FindComponentsRecursive(child, results);
-            }
-        }
-#endif
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void EventReset() { }

--- a/Scripts/Hakoniwa/HakoSim/Drone/DroneAvatar.cs.uid
+++ b/Scripts/Hakoniwa/HakoSim/Drone/DroneAvatar.cs.uid
@@ -1,1 +1,1 @@
-uid://i3gkj80ake1h
+uid://c2np2chmdjnds

--- a/Scripts/Hakoniwa/HakoSim/Drone/LiDAR3DController.cs
+++ b/Scripts/Hakoniwa/HakoSim/Drone/LiDAR3DController.cs
@@ -17,36 +17,12 @@ namespace hakoniwa.drone.sim
             {
                 return controller;
             }
-//            controller = FindComponent<ILiDAR3DController>(this);
-            controller = FindNodeByInterface<ILiDAR3DController>(this);
+            controller = NodeUtil.FindNodeByInterface<ILiDAR3DController>(this);
             if (controller == null)
             {
                 throw new Exception("Can not find ILiDAR3DController");
             }
             return controller;
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void DoInitialize(string robotName, IHakoPdu hakoPdu)

--- a/Scripts/Hakoniwa/HakoSim/GUI/SimStart.cs
+++ b/Scripts/Hakoniwa/HakoSim/GUI/SimStart.cs
@@ -45,8 +45,7 @@ namespace hakoniwa.gui.sim
                 {
                     // If no label assigned, we might want to use button's own text
                     // but myText is used in many places. Let's see if there is a Label child.
-//                    myText = FindComponent<Label>(myButton);
-                    myText = FindNodeByInterface<Label>(myButton);
+                    myText = NodeUtil.FindNodeByInterface<Label>(myButton);
                 }
             }
             if (myText != null)
@@ -57,29 +56,6 @@ namespace hakoniwa.gui.sim
             {
                 myButton.Text = "START";
             }
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         private void SetText(string text)

--- a/Scripts/NodeUtil.cs
+++ b/Scripts/NodeUtil.cs
@@ -1,0 +1,35 @@
+using Godot;
+using System.Collections.Generic;
+
+
+public static class NodeUtil
+{
+    public static T FindNodeByInterface<T>(Node root) where T : class
+    {
+        if (root is T found) return found;
+
+        foreach (Node child in root.GetChildren())
+        {
+            var result = FindNodeByInterface<T>(child);
+            if (result != null) return result;
+        }
+        return null;
+    }
+
+    public static void _FindComponentsRecursive<T>(Node node, List<T> results) where T : class
+    {
+        if (node == null) return;
+
+        // 1. 自分自身が型 T にキャストできるかチェック
+        if (node is T found)
+        {
+            results.Add(found);
+        }
+
+        // 2. 子ノードに対して再帰的に処理  
+        foreach (Node child in node.GetChildren())
+        {
+            _FindComponentsRecursive(child, results);
+        }
+    }
+}

--- a/Scripts/NodeUtil.cs.uid
+++ b/Scripts/NodeUtil.cs.uid
@@ -1,0 +1,1 @@
+uid://6s1vbludwr14

--- a/Scripts/Unity/Baggage/Baggage.cs
+++ b/Scripts/Unity/Baggage/Baggage.cs
@@ -24,38 +24,13 @@ namespace hakoniwa.objects.core
             initial_parent = GetParent();
 
             // Rigidbodyコンポーネントを取得
-//            rd = FindComponent<RigidBody3D>(this);
-            rd = FindNodeByInterface<RigidBody3D>(this);
+            rd = NodeUtil.FindNodeByInterface<RigidBody3D>(this);
             if (rd == null)
             {
                 GD.Print($"Not found RigidBody3D on {this.Name}");
             }
         }
 
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-        
         /// <summary>
         /// 他のオブジェクトに掴まれる（親として登録される）
         /// </summary>

--- a/Scripts/Unity/Baggage/Magnet.cs
+++ b/Scripts/Unity/Baggage/Magnet.cs
@@ -27,8 +27,7 @@ namespace hakoniwa.objects.core
             if (magnetRenderer == null)
             {
                 // Try to find a MeshInstance3D on this node or children
-//                magnetRenderer = FindComponent<MeshInstance3D>(this);
-                magnetRenderer = FindNodeByInterface<MeshInstance3D>(this);
+                magnetRenderer = NodeUtil.FindNodeByInterface<MeshInstance3D>(this);
             }
 
             if (magnetRenderer == null)
@@ -53,30 +52,6 @@ namespace hakoniwa.objects.core
             }
         }
 
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-        
         public override void _PhysicsProcess(double delta)
         {
             if (on && currentBaggage == null)

--- a/Scripts/Unity/Baggage/TouchSensor.cs
+++ b/Scripts/Unity/Baggage/TouchSensor.cs
@@ -20,8 +20,7 @@ namespace hakoniwa.objects.core
             var parent = t.GetParent();
             if (parent != null) {
                 GD.Print("ENTER:" + parent.Name);
-//                Baggage baggage = FindComponent<Baggage>(parent);
-                Baggage baggage = FindNodeByInterface<Baggage>(parent);
+                Baggage baggage = NodeUtil.FindNodeByInterface<Baggage>(parent);
                 if (baggage != null)
                 {
                     baggage.Grab(holder);
@@ -31,30 +30,6 @@ namespace hakoniwa.objects.core
 
         }
 
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
 
         void OnTriggerStay(CollisionObject3D t)
         {

--- a/Scripts/Unity/Sensors/Camera/DefaultCameraController.cs
+++ b/Scripts/Unity/Sensors/Camera/DefaultCameraController.cs
@@ -112,7 +112,7 @@ namespace hakoniwa.objects.core.sensors
         {
             if (this.my_camera == null)
             {
-                this.my_camera = FindNodeByInterface<Camera3D>(this);
+                this.my_camera = NodeUtil.FindNodeByInterface<Camera3D>(this);
             }
             
             if (my_camera == null)
@@ -125,7 +125,7 @@ namespace hakoniwa.objects.core.sensors
             // Create SubViewport for off-screen rendering if not found
             if (_viewport == null)
             {
-                _viewport = FindNodeByInterface<SubViewport>(this);
+                _viewport = NodeUtil.FindNodeByInterface<SubViewport>(this);
             }
 
             if (_viewport == null)
@@ -166,30 +166,6 @@ namespace hakoniwa.objects.core.sensors
                 mat.AlbedoTexture = _viewport.GetTexture();
                 targetRenderer.MaterialOverride = mat;
             }
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
 
         public void RotateCamera(float step)

--- a/Scripts/Unity/Sensors/Camera/HakoCamera.cs
+++ b/Scripts/Unity/Sensors/Camera/HakoCamera.cs
@@ -15,8 +15,7 @@ namespace hakoniwa.objects.core.sensors
         public void ConfigureCamera(string cameraId, string cameraType, string _encode_type, string coordinate_type, string target, Vector3 position, Vector3 rotation, float fov, int width, int height)
         {
             // 1. Get or Create Camera3D
-//            _camera = FindComponent<Camera3D>(this);
-            _camera = FindNodeByInterface<Camera3D>(this);
+            _camera = NodeUtil.FindNodeByInterface<Camera3D>(this);
             if (_camera == null)
             {
                 _camera = new Camera3D();
@@ -56,7 +55,7 @@ namespace hakoniwa.objects.core.sensors
                     GD.PrintErr("Can not find Node: " + target);
                     return;
                 }
-                targetObject = FindComponent<IMovableObject>(obj);
+                targetObject = NodeUtil.FindNodeByInterface<IMovableObject>(obj);
                 if (targetObject == null)
                 {
                     GD.PrintErr("Can not find IMovableObject: " + target);
@@ -126,29 +125,6 @@ namespace hakoniwa.objects.core.sensors
             {
                 return img.SaveJpgToBuffer();
             }
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
     }
 }

--- a/Scripts/Unity/Sensors/Camera/MonitorCameraManager.cs
+++ b/Scripts/Unity/Sensors/Camera/MonitorCameraManager.cs
@@ -127,8 +127,7 @@ namespace hakoniwa.objects.core.sensors
             {
                 // Godot: Instantiate PackedScene
                 Node3D newCamera = cameraPrefab.Instantiate<Node3D>();
-//                HakoCamera hakoCamera = FindComponent<HakoCamera>(newCamera);
-                HakoCamera hakoCamera = FindNodeByInterface<HakoCamera>(newCamera);
+                HakoCamera hakoCamera = NodeUtil.FindNodeByInterface<HakoCamera>(newCamera);
                 if (hakoCamera == null)
                 {
                     GD.PrintErr($"Failed to get HakoCamera component for {camData.pdu_info.robot_name}");
@@ -161,29 +160,6 @@ namespace hakoniwa.objects.core.sensors
 
                 hakoCameras[camData.pdu_info.robot_name] = hakoCamera;
             }
-        }
-
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
         }
     }
 }

--- a/Scripts/Unity/TargetColliderInfo.cs
+++ b/Scripts/Unity/TargetColliderInfo.cs
@@ -81,13 +81,11 @@ namespace hakoniwa.objects.core
         {
             if (rb == null)
             {
-//                rb = FindComponent<RigidBody3D>(GetParent());
-                rb = FindNodeByInterface<RigidBody3D>(GetParent());
+                rb = NodeUtil.FindNodeByInterface<RigidBody3D>(GetParent());
             }
             if (collider_obj == null)
             {
-//                collider_obj = FindComponent<CollisionObject3D>(GetParent());
-                collider_obj = FindNodeByInterface<CollisionObject3D>(GetParent());
+                collider_obj = NodeUtil.FindNodeByInterface<CollisionObject3D>(GetParent());
             }
 
             if (collider_obj == null)
@@ -110,29 +108,6 @@ namespace hakoniwa.objects.core
             currentTime = 0;
         }
 
-        private T FindComponent<T>(Node node) where T : class
-        {
-            if (node is T found) return found;
-            foreach (Node child in node.GetChildren())
-            {
-                var result = FindComponent<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
-
-
-        public T FindNodeByInterface<T>(Node root) where T : class
-        {
-            if (root is T found) return found;
-
-            foreach (Node child in root.GetChildren())
-            {
-                var result = FindNodeByInterface<T>(child);
-                if (result != null) return result;
-            }
-            return null;
-        }
         public override void _ExitTree()
         {
             if (collider_obj != null)

--- a/Scripts/hakoniwa-sim/sim/HakoAsset.cs
+++ b/Scripts/hakoniwa-sim/sim/HakoAsset.cs
@@ -58,8 +58,7 @@ public partial class HakoAsset: Node, IHakoPdu, IHakoControl
         if (hakoObjects == null) return false;
         foreach (var obj in hakoObjects)
         {
-//            IHakoObject ihako = FindComponent<IHakoObject>(obj);
-            IHakoObject ihako = FindNodeByInterface<IHakoObject>(obj);
+            IHakoObject ihako = NodeUtil.FindNodeByInterface<IHakoObject>(obj);
             if (ihako == null)
             {
                 throw new ArgumentException("Can not find IHakoObject on " + obj.Name);
@@ -67,30 +66,6 @@ public partial class HakoAsset: Node, IHakoPdu, IHakoControl
             hakoObectList.Add(ihako);
         }
         return hakoObectList.Count > 0;
-    }
-
-    private T FindComponent<T>(Node root) where T : class
-    {
-        if (root is T t) return t;
-        foreach (Node child in root.GetChildren())
-        {
-            var res = FindComponent<T>(child);
-            if (res != null) return res;
-        }
-        return null;
-    }
-
-
-    public T FindNodeByInterface<T>(Node root) where T : class
-    {
-        if (root is T found) return found;
-
-        foreach (Node child in root.GetChildren())
-        {
-            var result = FindNodeByInterface<T>(child);
-            if (result != null) return result;
-        }
-        return null;
     }
 
     public override async void _Ready()


### PR DESCRIPTION
・NodeUtil.csにFindNodeByInterface()と_FindComponentsRecursive()を定義
・各ファイルで定義していたFindNodeByInterface()を削除し、上記をコールするよう変更
・各ファイルのFindComponent()は未使用のため削除
・各ファイルのFindComponents()を変更